### PR TITLE
Persistent notifications

### DIFF
--- a/client/src/components/messages/Message.jsx
+++ b/client/src/components/messages/Message.jsx
@@ -25,11 +25,13 @@ const Message = ({ message, lastSeenByReceiver }) => {
 			</div>
 			<div className="chat-footer opacity-50 text-platinum text-xs flex gap-1 items-center">
 				{formattedTimestamp}
-				{isFromMe ? '' : (message.createdAt > lastSeenByReceiver ? (
+				{!isFromMe ? (
+					''
+				) : message.createdAt > lastSeenByReceiver ? (
 					<TiTickOutline />
 				) : (
 					<TiTick className="text-lime-green" />
-				))}
+				)}
 			</div>
 		</div>
 	);

--- a/client/src/components/messages/Message.jsx
+++ b/client/src/components/messages/Message.jsx
@@ -1,13 +1,26 @@
 import dayjs from 'dayjs';
 import { useAuthContext } from '../../context/AuthContext';
 import { TiTick, TiTickOutline } from 'react-icons/ti';
+import { useEffect, useState } from 'react';
 
-const Message = ({ message, lastSeenByReceiver }) => {
+const Message = ({ message, lastSeenByReceiver, lastSeenUpdatedSub }) => {
 	const { authUser } = useAuthContext();
+	const [isRead, setIsRead] = useState(
+		message.createdAt < lastSeenByReceiver
+	);
 	const formattedTimestamp = dayjs
 		.unix(message.createdAt / 1000)
 		.format('hh:mm a');
 	const isFromMe = message.senderId._id === authUser._id;
+
+	useEffect(() => {
+		if (!lastSeenUpdatedSub.loading && lastSeenUpdatedSub.data) {
+			setIsRead(
+				message.createdAt <
+					lastSeenUpdatedSub.data.lastSeenUpdatedSub.lastSeen
+			);
+		}
+	}, [lastSeenUpdatedSub.data?.lastSeenUpdatedSub.lastSeen]);
 
 	return (
 		<div className={`chat ${isFromMe ? 'chat-end' : 'chat-start'}`}>
@@ -27,10 +40,10 @@ const Message = ({ message, lastSeenByReceiver }) => {
 				{formattedTimestamp}
 				{!isFromMe ? (
 					''
-				) : message.createdAt > lastSeenByReceiver ? (
-					<TiTickOutline />
-				) : (
+				) : isRead ? (
 					<TiTick className="text-lime-green" />
+				) : (
+					<TiTickOutline />
 				)}
 			</div>
 		</div>

--- a/client/src/components/messages/Message.jsx
+++ b/client/src/components/messages/Message.jsx
@@ -1,7 +1,9 @@
 import dayjs from 'dayjs';
 import { useAuthContext } from '../../context/AuthContext';
+import { TiTick, TiTickOutline } from "react-icons/ti";
 
-const Message = ({ message }) => {
+
+const Message = ({ message, lastSeenByReceiver }) => {
 	const { authUser } = useAuthContext();
 	const formattedTimestamp = dayjs
 		.unix(message.createdAt / 1000)
@@ -22,8 +24,9 @@ const Message = ({ message }) => {
 			>
 				{message.content}
 			</div>
-			<div className="chat-footer opacity-50 text-xs flex gap-1 items-center">
+			<div className="chat-footer opacity-50 text-platinum text-xs flex gap-1 items-center">
 				{formattedTimestamp}
+				{message.createdAt > lastSeenByReceiver ? <TiTickOutline /> : <TiTick className='text-lime-green' />}
 			</div>
 		</div>
 	);

--- a/client/src/components/messages/Message.jsx
+++ b/client/src/components/messages/Message.jsx
@@ -1,7 +1,6 @@
 import dayjs from 'dayjs';
 import { useAuthContext } from '../../context/AuthContext';
-import { TiTick, TiTickOutline } from "react-icons/ti";
-
+import { TiTick, TiTickOutline } from 'react-icons/ti';
 
 const Message = ({ message, lastSeenByReceiver }) => {
 	const { authUser } = useAuthContext();
@@ -26,7 +25,11 @@ const Message = ({ message, lastSeenByReceiver }) => {
 			</div>
 			<div className="chat-footer opacity-50 text-platinum text-xs flex gap-1 items-center">
 				{formattedTimestamp}
-				{message.createdAt > lastSeenByReceiver ? <TiTickOutline /> : <TiTick className='text-lime-green' />}
+				{isFromMe ? '' : (message.createdAt > lastSeenByReceiver ? (
+					<TiTickOutline />
+				) : (
+					<TiTick className="text-lime-green" />
+				))}
 			</div>
 		</div>
 	);

--- a/client/src/components/messages/MessageContainer.jsx
+++ b/client/src/components/messages/MessageContainer.jsx
@@ -1,9 +1,7 @@
 import { useEffect } from 'react';
-import { useAuthContext } from '../../context/AuthContext';
 import useChatStore from '../../store/useChatStore';
 import MessageInput from './MessageInput';
 import Messages from './Messages';
-import { TiMessages } from 'react-icons/ti';
 
 const MessageContainer = () => {
 	const { selectedChat, setSelectedChat } = useChatStore();
@@ -15,36 +13,10 @@ const MessageContainer = () => {
 
 	return (
 		<div className="flex flex-col w-full static">
-			{selectedChat ? (
-				<>
-					<div className="bg-tea-green px-4 py-2 mb-2">
-						<span className="label-text text-new-slate">To:</span>{' '}
-						<span className="text-rich-black font-bold">
-							{selectedChat.username}
-						</span>
-					</div>
-
-					<Messages />
-					<MessageInput />
-				</>
-			) : (
-				<NoChatSelected />
-			)}
+			<Messages />
+			{selectedChat ? <MessageInput /> : ''}
 		</div>
 	);
 };
 
 export default MessageContainer;
-
-const NoChatSelected = () => {
-	const { authUser } = useAuthContext();
-	return (
-		<div className="flex items-center justify-center w-full h-full">
-			<div className="px-4 text-center sm:text-lg md:text-xl text-mint-green font-semibold flex flex-col items-center gap-2">
-				<p>Welcome {authUser.username}</p>
-				<p>Select a chat to start messaging</p>
-				<TiMessages className="text-3xl md:text-6xl text-center" />
-			</div>
-		</div>
-	);
-};

--- a/client/src/components/messages/Messages.jsx
+++ b/client/src/components/messages/Messages.jsx
@@ -25,6 +25,11 @@ const Messages = () => {
 	const [messages, setMessages] = useState([]);
 	const lastMessageRef = useRef();
 	const { notifications, setNotifications } = useNotificationContext();
+	const [chat, setChat] = useState(null);
+	const lastSeenByReceiver =
+		authUser._id === chat?.participantOne._id
+			? chat?.lastSeenByTwo
+			: chat?.lastSeenByOne;
 
 	const subscription = useSubscription(NEW_MESSAGE, {
 		variables: {
@@ -86,6 +91,7 @@ const Messages = () => {
 		}
 		if (data?.chat) {
 			setMessages(data.chat.messages);
+			setChat(data.chat);
 		}
 	}, [data, error]);
 
@@ -153,9 +159,7 @@ const Messages = () => {
 						<div key={message._id} ref={lastMessageRef}>
 							<Message
 								message={message}
-								lastSeenByReceiver={
-									selectedChat.lastSeenByReceiver
-								}
+								lastSeenByReceiver={lastSeenByReceiver}
 							/>
 						</div>
 					))

--- a/client/src/components/messages/Messages.jsx
+++ b/client/src/components/messages/Messages.jsx
@@ -107,11 +107,8 @@ const Messages = () => {
 				return;
 			}
 
-			console.log(selectedChat);
-
 			// if message sent to a non-selected chat add id to notifications array
 			if (!selectedChat || newMessage.senderId._id !== selectedChat?._id) {
-				console.log(selectedChat);
 				setNotifications([...notifications, newMessage.senderId._id]);
 			}
 		}

--- a/client/src/components/messages/Messages.jsx
+++ b/client/src/components/messages/Messages.jsx
@@ -123,7 +123,7 @@ const Messages = () => {
 			) : (
 				messages.map((message) => (
 					<div key={message._id} ref={lastMessageRef}>
-						<Message message={message} />
+						<Message message={message} lastSeenByReceiver={selectedChat.lastSeenByReceiver} />
 					</div>
 				))
 			)}

--- a/client/src/components/messages/Messages.jsx
+++ b/client/src/components/messages/Messages.jsx
@@ -6,7 +6,11 @@ import { useEffect, useRef, useState } from 'react';
 import MessageSkeleton from '../skeleton/MessageSkeleton';
 import { useAuthContext } from '../../context/AuthContext';
 import { useSubscription } from '@apollo/client';
-import { IS_TYPING_SUB, NEW_MESSAGE } from '../../utils/subscriptions';
+import {
+	IS_TYPING_SUB,
+	LAST_SEEN_UPDATED_SUB,
+	NEW_MESSAGE,
+} from '../../utils/subscriptions';
 import messagePopAlert from '../../assets/happy-pop-3-185288.mp3';
 import typingPopAlert from '../../assets/multi-pop-1-188165.mp3';
 import { useNotificationContext } from '../../context/NotificationContext';
@@ -42,6 +46,7 @@ const Messages = () => {
 	const isTypingSubscription = useSubscription(IS_TYPING_SUB);
 
 	const [updateLastSeen] = useMutation(UPDATE_LAST_SEEN);
+	const lastSeenUpdatedSub = useSubscription(LAST_SEEN_UPDATED_SUB);
 
 	useEffect(() => {
 		if (!isTypingSubscription.loading && isTypingSubscription.data) {
@@ -114,11 +119,14 @@ const Messages = () => {
 				setTypingIndicator(false);
 
 				// update lastSeenBy
-				updateLastSeen({
-					variables: {
-						selectedChatId: selectedChat._id,
-					},
-				});
+				if (newMessage.senderId._id !== authUser._id) {
+					updateLastSeen({
+						variables: {
+							senderId: newMessage.senderId._id,
+							receiverId: newMessage.receiverId._id,
+						},
+					});
+				}
 				return;
 			}
 
@@ -160,6 +168,7 @@ const Messages = () => {
 							<Message
 								message={message}
 								lastSeenByReceiver={lastSeenByReceiver}
+								lastSeenUpdatedSub={lastSeenUpdatedSub}
 							/>
 						</div>
 					))

--- a/client/src/components/messages/Messages.jsx
+++ b/client/src/components/messages/Messages.jsx
@@ -1,4 +1,4 @@
-import { useQuery } from '@apollo/client';
+import { useMutation, useQuery } from '@apollo/client';
 import useChatStore from '../../store/useChatStore';
 import Message from './Message';
 import { CHAT } from '../../utils/queries';
@@ -11,6 +11,7 @@ import messagePopAlert from '../../assets/happy-pop-3-185288.mp3';
 import typingPopAlert from '../../assets/multi-pop-1-188165.mp3';
 import { useNotificationContext } from '../../context/NotificationContext';
 import { TiMessages, TiMessageTyping } from 'react-icons/ti';
+import { UPDATE_LAST_SEEN } from '../../utils/mutations';
 
 const Messages = () => {
 	const { selectedChat } = useChatStore();
@@ -33,8 +34,9 @@ const Messages = () => {
 	});
 
 	const [typingIndicator, setTypingIndicator] = useState(false);
-
 	const isTypingSubscription = useSubscription(IS_TYPING_SUB);
+
+	const [updateLastSeen] = useMutation(UPDATE_LAST_SEEN);
 
 	useEffect(() => {
 		if (!isTypingSubscription.loading && isTypingSubscription.data) {
@@ -104,11 +106,21 @@ const Messages = () => {
 
 				setMessages([...messages, newMessage]);
 				setTypingIndicator(false);
+
+				// update lastSeenBy
+				updateLastSeen({
+					variables: {
+						selectedChatId: selectedChat._id,
+					},
+				});
 				return;
 			}
 
 			// if message sent to a non-selected chat add id to notifications array
-			if (!selectedChat || newMessage.senderId._id !== selectedChat?._id) {
+			if (
+				!selectedChat ||
+				newMessage.senderId._id !== selectedChat?._id
+			) {
 				setNotifications([...notifications, newMessage.senderId._id]);
 			}
 		}
@@ -117,14 +129,15 @@ const Messages = () => {
 	return (
 		<>
 			{selectedChat ? (
-			<div className="bg-tea-green px-4 py-2 mb-2">
-				<span className="label-text text-new-slate">To:</span>{' '}
-				<span className="text-rich-black font-bold">
-					{selectedChat?.username}
-				</span>
-			</div>
-
-			) : (<NoChatSelected />)}
+				<div className="bg-tea-green px-4 py-2 mb-2">
+					<span className="label-text text-new-slate">To:</span>{' '}
+					<span className="text-rich-black font-bold">
+						{selectedChat?.username}
+					</span>
+				</div>
+			) : (
+				<NoChatSelected />
+			)}
 
 			<div className="px-4 flex-1 overflow-auto relative">
 				{loading ? (

--- a/client/src/components/sidebar/Chat.jsx
+++ b/client/src/components/sidebar/Chat.jsx
@@ -3,42 +3,42 @@ import { useOnlineUserContext } from '../../context/OnlineUserContext';
 import { useNotificationContext } from '../../context/NotificationContext';
 import { useEffect } from 'react';
 import { useSidebarContext } from './Sidebar';
-import { useAuthContext } from '../../context/AuthContext';
+// import { useAuthContext } from '../../context/AuthContext';
 
-const Chat = ({ chat, lastIndex }) => {
+const Chat = ({ user, lastIndex }) => {
 	const { selectedChat, setSelectedChat } = useChatStore();
-	const { authUser } = useAuthContext();
+	// const { authUser } = useAuthContext();
 	const { onlineUsers } = useOnlineUserContext();
-	const isParticipantOne = chat.participantOne._id === authUser._id;
-	const participant = isParticipantOne
-		? chat.participantTwo
-		: chat.participantOne;
-	const lastSeenByReceiver = isParticipantOne
-		? chat.lastSeenByTwo
-		: chat.lastSeenByOne;
-	const lastSeenByUser = isParticipantOne
-		? chat.lastSeenByOne
-		: chat.lastSeenByTwo;
-	const chatId = participant._id;
+	// const isParticipantOne = chat.participantOne._id === authUser._id;
+	// const participant = isParticipantOne
+	// 	? chat.participantTwo
+	// 	: chat.participantOne;
+	// const lastSeenByReceiver = isParticipantOne
+	// 	? chat.lastSeenByTwo
+	// 	: chat.lastSeenByOne;
+	// const lastSeenByUser = isParticipantOne
+	// 	? chat.lastSeenByOne
+	// 	: chat.lastSeenByTwo;
+	// const chatId = participant._id;
 
-	const isSelected = selectedChat?._id === chatId;
+	const isSelected = selectedChat?._id === user._id;
 
-	const isOnline = onlineUsers.includes(chatId);
+	const isOnline = onlineUsers.includes(user._id);
 
 	const { notifications, setNotifications } = useNotificationContext();
 	// check notification context first
-	let hasNotification = notifications.includes(chatId);
+	let hasNotification = notifications.includes(user._id);
 	// if none in notification context check if last seen by data reveals unread messages
-	if (!hasNotification) {
-		// if last mesage is not from authUser and createdAt is newer than lastSeenByUser it hasNotification
-		hasNotification = chat.messages.at(-1).senderId._id !== authUser._id && lastSeenByUser < chat.messages.at(-1).createdAt;
-	}
+	// if (!hasNotification) {
+	// 	// if last mesage is not from authUser and createdAt is newer than lastSeenByUser it hasNotification
+	// 	hasNotification = chat.messages.at(-1)?.senderId._id !== authUser._id && lastSeenByUser < chat.messages.at(-1)?.createdAt;
+	// }
 
 	const { expanded } = useSidebarContext();
 
 	useEffect(() => {
 		// if chat with notification is selected remove from the notifications array
-		if (hasNotification && selectedChat?._id === chatId) {
+		if (hasNotification && selectedChat?._id === user._id) {
 			const nextNotifications = notifications.filter(
 				(notification) => notification !== selectedChat._id
 			);
@@ -48,8 +48,8 @@ const Chat = ({ chat, lastIndex }) => {
 
 	const handleChatSelect = async () => {
 		setSelectedChat({
-			...participant,
-			lastSeenByReceiver,
+			...user,
+			// lastSeenByReceiver,
 		});
 	};
 
@@ -72,7 +72,7 @@ const Chat = ({ chat, lastIndex }) => {
 								// isParticipantOne
 								// 	? chat.participantTwo.avatar
 								// 	: chat.participantOne.avatar
-								participant.avatar
+								user.avatar
 							}
 							alt="user avatar"
 						/>
@@ -90,7 +90,7 @@ const Chat = ({ chat, lastIndex }) => {
 								// isParticipantOne
 								// 	? chat.participantTwo.username
 								// 	: chat.participantOne.username
-								participant.username
+								user.username
 							}
 						</p>
 						<span className="text-xl">

--- a/client/src/components/sidebar/Chat.jsx
+++ b/client/src/components/sidebar/Chat.jsx
@@ -3,22 +3,34 @@ import { useOnlineUserContext } from '../../context/OnlineUserContext';
 import { useNotificationContext } from '../../context/NotificationContext';
 import { useEffect } from 'react';
 import { useSidebarContext } from './Sidebar';
+import { useAuthContext } from '../../context/AuthContext';
 
 const Chat = ({ chat, lastIndex }) => {
 	const { selectedChat, setSelectedChat } = useChatStore();
-	const isSelected = selectedChat?._id === chat._id;
+	const { authUser } = useAuthContext();
 	const { onlineUsers } = useOnlineUserContext();
+	// const isParticipantOne = chat.participantOne._id === authUser._id;
+	const participant =
+		chat.participantOne._id === authUser._id
+			? chat.participantTwo
+			: chat.participantOne;
+	// const chatId = isParticipantOne
+	// 	? chat.participantTwo._id
+	// 	: chat.participantOne._id;
+	const chatId = participant._id;
 
-	const isOnline = onlineUsers.includes(chat._id);
+	const isSelected = selectedChat?._id === chatId;
+
+	const isOnline = onlineUsers.includes(chatId);
 
 	const { notifications, setNotifications } = useNotificationContext();
-	const hasNotification = notifications.includes(chat._id);
+	const hasNotification = notifications.includes(chatId);
 
 	const { expanded } = useSidebarContext();
 
 	useEffect(() => {
 		// if chat with notification is selected remove from the notifications array
-		if (hasNotification && selectedChat._id === chat._id) {
+		if (hasNotification && selectedChat._id === chatId) {
 			const nextNotifications = notifications.filter(
 				(notification) => notification !== selectedChat._id
 			);
@@ -27,7 +39,10 @@ const Chat = ({ chat, lastIndex }) => {
 	}, [selectedChat]);
 
 	const handleChatSelect = async () => {
-		setSelectedChat(chat);
+		// isParticipantOne
+		// 	? setSelectedChat(chat.participantTwo)
+		// 	: setSelectedChat(chat.participantOne);
+		setSelectedChat(participant);
 	};
 
 	return (
@@ -44,7 +59,15 @@ const Chat = ({ chat, lastIndex }) => {
 			>
 				<div className={`avatar ${isOnline ? 'online' : ''}`}>
 					<div className="w-12 rounded-full">
-						<img src={chat.avatar} alt="user avatar" />
+						<img
+							src={
+								// isParticipantOne
+								// 	? chat.participantTwo.avatar
+								// 	: chat.participantOne.avatar
+								participant.avatar
+							}
+							alt="user avatar"
+						/>
 					</div>
 				</div>
 
@@ -55,7 +78,12 @@ const Chat = ({ chat, lastIndex }) => {
 				>
 					<div className="flex gap-3 justify-between">
 						<p className="font-bold text-mint-green">
-							{chat.username}
+							{
+								// isParticipantOne
+								// 	? chat.participantTwo.username
+								// 	: chat.participantOne.username
+								participant.username
+							}
 						</p>
 						<span className="text-xl">
 							{hasNotification ? '!!!!!' : ':]'}

--- a/client/src/components/sidebar/Chat.jsx
+++ b/client/src/components/sidebar/Chat.jsx
@@ -9,11 +9,13 @@ const Chat = ({ chat, lastIndex }) => {
 	const { selectedChat, setSelectedChat } = useChatStore();
 	const { authUser } = useAuthContext();
 	const { onlineUsers } = useOnlineUserContext();
-	// const isParticipantOne = chat.participantOne._id === authUser._id;
-	const participant =
-		chat.participantOne._id === authUser._id
-			? chat.participantTwo
-			: chat.participantOne;
+	const isParticipantOne = chat.participantOne._id === authUser._id;
+	const participant = isParticipantOne
+		? chat.participantTwo
+		: chat.participantOne;
+	const lastSeenByReceiver = isParticipantOne
+		? chat.lastSeenByTwo
+		: chat.lastSeenByOne;
 	// const chatId = isParticipantOne
 	// 	? chat.participantTwo._id
 	// 	: chat.participantOne._id;
@@ -42,7 +44,10 @@ const Chat = ({ chat, lastIndex }) => {
 		// isParticipantOne
 		// 	? setSelectedChat(chat.participantTwo)
 		// 	: setSelectedChat(chat.participantOne);
-		setSelectedChat(participant);
+		setSelectedChat({
+			...participant,
+			lastSeenByReceiver,
+		});
 	};
 
 	return (

--- a/client/src/components/sidebar/Chat.jsx
+++ b/client/src/components/sidebar/Chat.jsx
@@ -30,7 +30,8 @@ const Chat = ({ chat, lastIndex }) => {
 	let hasNotification = notifications.includes(chatId);
 	// if none in notification context check if last seen by data reveals unread messages
 	if (!hasNotification) {
-		hasNotification = lastSeenByUser < chat.messages.at(-1).createdAt;
+		// if last mesage is not from authUser and createdAt is newer than lastSeenByUser it hasNotification
+		hasNotification = chat.messages.at(-1).senderId._id !== authUser._id && lastSeenByUser < chat.messages.at(-1).createdAt;
 	}
 
 	const { expanded } = useSidebarContext();

--- a/client/src/components/sidebar/Chat.jsx
+++ b/client/src/components/sidebar/Chat.jsx
@@ -16,9 +16,9 @@ const Chat = ({ chat, lastIndex }) => {
 	const lastSeenByReceiver = isParticipantOne
 		? chat.lastSeenByTwo
 		: chat.lastSeenByOne;
-	// const chatId = isParticipantOne
-	// 	? chat.participantTwo._id
-	// 	: chat.participantOne._id;
+	const lastSeenByUser = isParticipantOne
+		? chat.lastSeenByOne
+		: chat.lastSeenByTwo;
 	const chatId = participant._id;
 
 	const isSelected = selectedChat?._id === chatId;
@@ -26,13 +26,18 @@ const Chat = ({ chat, lastIndex }) => {
 	const isOnline = onlineUsers.includes(chatId);
 
 	const { notifications, setNotifications } = useNotificationContext();
-	const hasNotification = notifications.includes(chatId);
+	// check notification context first
+	let hasNotification = notifications.includes(chatId);
+	// if none in notification context check if last seen by data reveals unread messages
+	if (!hasNotification) {
+		hasNotification = lastSeenByUser < chat.messages.at(-1).createdAt;
+	}
 
 	const { expanded } = useSidebarContext();
 
 	useEffect(() => {
 		// if chat with notification is selected remove from the notifications array
-		if (hasNotification && selectedChat._id === chatId) {
+		if (hasNotification && selectedChat?._id === chatId) {
 			const nextNotifications = notifications.filter(
 				(notification) => notification !== selectedChat._id
 			);
@@ -41,9 +46,6 @@ const Chat = ({ chat, lastIndex }) => {
 	}, [selectedChat]);
 
 	const handleChatSelect = async () => {
-		// isParticipantOne
-		// 	? setSelectedChat(chat.participantTwo)
-		// 	: setSelectedChat(chat.participantOne);
 		setSelectedChat({
 			...participant,
 			lastSeenByReceiver,

--- a/client/src/components/sidebar/Chat.jsx
+++ b/client/src/components/sidebar/Chat.jsx
@@ -39,10 +39,12 @@ const Chat = ({ user, lastIndex }) => {
 	}, [notifications]);
 
 	useEffect(() => {
-		if (!hasNotification && notificationsResponse.loading === false) {
-			if (notificationsResponse.data?.notifications.includes(user._id)) {
-				setHasNotification(true);
-			}
+		if (
+			!hasNotification &&
+			!notificationsResponse.loading &&
+			notificationsResponse.data?.notifications.includes(user._id)
+		) {
+			setHasNotification(true);
 		}
 	}, [notificationsResponse]);
 

--- a/client/src/components/sidebar/Chats.jsx
+++ b/client/src/components/sidebar/Chats.jsx
@@ -50,7 +50,11 @@ const Chats = () => {
 							''
 						);
 					})}
-					{onlineChats.length > 0 ? <div className="divider my-0 py-0 h-1 divider-success" /> : ''}
+					{onlineChats.length > 0 ? (
+						<div className="divider my-0 py-0 h-1 divider-success" />
+					) : (
+						''
+					)}
 					{offlineChats.map((chat, index) => {
 						return authUser._id !== chat._id ? (
 							<Chat

--- a/client/src/components/sidebar/Chats.jsx
+++ b/client/src/components/sidebar/Chats.jsx
@@ -1,40 +1,41 @@
-import useGetChats from '../../hooks/useGetChats';
+// import useGetChats from '../../hooks/useGetChats';
 import Chat from './Chat';
 import { useAuthContext } from '../../context/AuthContext';
 import { useEffect, useState } from 'react';
 import { useOnlineUserContext } from '../../context/OnlineUserContext';
+import useGetUsers from '../../hooks/useGetUsers';
 
 const Chats = () => {
-	const { loading, chats } = useGetChats();
+	const { loading, users } = useGetUsers();
 	const { authUser } = useAuthContext();
 	const { onlineUsers } = useOnlineUserContext();
-	const [onlineChats, setOnlineChats] = useState([]);
-	const [offlineChats, setOfflineChats] = useState([]);
+	const [onlineUsersSection, setOnlineUsersSection] = useState([]);
+	const [offlineUsersSection, setOfflineUsersSection] = useState([]);
 
 	useEffect(() => {
-		if (!loading && chats.length > 0) {
-			sortByOnlineStatus(chats);
+		if (!loading && users.length > 0) {
+			sortByOnlineStatus(users);
 		}
-	}, [chats, onlineUsers]);
+	}, [users, onlineUsers]);
 
-	const sortByOnlineStatus = (chats) => {
+	const sortByOnlineStatus = (users) => {
 		const online = [];
 		const offline = [];
 
-		chats.forEach((chat) => {
-			const isParticipantOne = chat.participantOne._id === authUser._id;
-			const participant = isParticipantOne
-				? chat.participantTwo
-				: chat.participantOne;
+		users.forEach((user) => {
+			// const isParticipantOne = chat.participantOne._id === authUser._id;
+			// const participant = isParticipantOne
+			// 	? chat.participantTwo
+			// 	: chat.participantOne;
 
-			if (participant._id !== authUser._id && onlineUsers.includes(participant._id)) {
-				online.push(chat);
+			if (user._id !== authUser._id && onlineUsers.includes(user._id)) {
+				online.push(user);
 			} else {
-				offline.push(chat);
+				offline.push(user);
 			}
 
-			setOnlineChats(online);
-			setOfflineChats(offline);
+			setOnlineUsersSection(online);
+			setOfflineUsersSection(offline);
 		});
 	};
 
@@ -44,28 +45,28 @@ const Chats = () => {
 				<span className="loading loading-spinner mx-auto"></span>
 			) : (
 				<>
-					{onlineChats.map((chat, index) => {
-						return authUser._id !== chat._id ? (
+					{onlineUsersSection.map((user, index) => {
+						return authUser._id !== user._id ? (
 							<Chat
-								key={chat._id}
-								chat={chat}
-								lastIndex={index === onlineChats.length - 1}
+								key={user._id}
+								user={user}
+								lastIndex={index === onlineUsersSection.length - 1}
 							/>
 						) : (
 							''
 						);
 					})}
-					{onlineChats.length > 0 ? (
+					{onlineUsersSection.length > 0 ? (
 						<div className="divider my-0 py-0 h-1 divider-success" />
 					) : (
 						''
 					)}
-					{offlineChats.map((chat, index) => {
-						return authUser._id !== chat._id ? (
+					{offlineUsersSection.map((user, index) => {
+						return authUser._id !== user._id ? (
 							<Chat
-								key={chat._id}
-								chat={chat}
-								lastIndex={index === offlineChats.length - 1}
+								key={user._id}
+								user={user}
+								lastIndex={index === offlineUsersSection.length - 1}
 							/>
 						) : (
 							''

--- a/client/src/components/sidebar/Chats.jsx
+++ b/client/src/components/sidebar/Chats.jsx
@@ -22,7 +22,12 @@ const Chats = () => {
 		const offline = [];
 
 		chats.forEach((chat) => {
-			if (chat._id !== authUser._id && onlineUsers.includes(chat._id)) {
+			const isParticipantOne = chat.participantOne._id === authUser._id;
+			const participant = isParticipantOne
+				? chat.participantTwo
+				: chat.participantOne;
+
+			if (participant._id !== authUser._id && onlineUsers.includes(participant._id)) {
 				online.push(chat);
 			} else {
 				offline.push(chat);

--- a/client/src/hooks/useGetChats.js
+++ b/client/src/hooks/useGetChats.js
@@ -1,6 +1,6 @@
 import { useQuery } from '@apollo/client';
 import { useEffect, useState } from 'react';
-import { USERS } from '../utils/queries';
+import { CHATS } from '../utils/queries';
 import toast from 'react-hot-toast';
 import { SIGNED_UP } from '../utils/subscriptions';
 
@@ -12,7 +12,7 @@ const useGetChats = () => {
 		data,
 		loading: loadingQuery,
 		subscribeToMore,
-	} = useQuery(USERS);
+	} = useQuery(CHATS);
 
 	useEffect(() => {
 		const getChats = () => {
@@ -28,7 +28,7 @@ const useGetChats = () => {
 					throw new Error(error);
 				}
 
-				setChats(data?.users || []);
+				setChats(data?.chats || []);
 			} catch (error) {
 				toast.error(error);
 			} finally {

--- a/client/src/hooks/useGetUsers.js
+++ b/client/src/hooks/useGetUsers.js
@@ -1,25 +1,25 @@
 import { useQuery } from '@apollo/client';
 import { useEffect, useState } from 'react';
-import { CHATS } from '../utils/queries';
+import { USERS } from '../utils/queries';
 import toast from 'react-hot-toast';
 import { SIGNED_UP } from '../utils/subscriptions';
 
-const useGetChats = () => {
+const useGetUsers = () => {
 	const [loading, setLoading] = useState(false);
-	const [chats, setChats] = useState([]);
+	const [users, setUsers] = useState([]);
 	const {
 		error,
 		data,
 		loading: loadingQuery,
 		subscribeToMore,
-	} = useQuery(CHATS);
+	} = useQuery(USERS);
 
 	useEffect(() => {
-		const getChats = () => {
+		const getUsers = () => {
 			setLoading(true);
 
 			if (loadingQuery || error) {
-				setChats([]);
+				setUsers([]);
 				return;
 			}
 
@@ -28,7 +28,7 @@ const useGetChats = () => {
 					throw new Error(error);
 				}
 
-				setChats(data?.chats || []);
+				setUsers(data?.users || []);
 			} catch (error) {
 				toast.error(error);
 			} finally {
@@ -36,7 +36,7 @@ const useGetChats = () => {
 			}
 		};
 
-		getChats();
+		getUsers();
 	}, [data]);
 
 	// subscribe to any new users
@@ -61,7 +61,7 @@ const useGetChats = () => {
 		});
 	}, []);
 
-	return { loading, chats };
+	return { loading, users };
 };
 
-export default useGetChats;
+export default useGetUsers;

--- a/client/src/pages/signup/Signup.jsx
+++ b/client/src/pages/signup/Signup.jsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import useSignup from '../../hooks/useSignup';
-import { useAuthContext } from '../../context/AuthContext';
 
 const Signup = () => {
 	const [formInputs, setFormInputs] = useState({
@@ -12,11 +11,6 @@ const Signup = () => {
 	});
 
 	const { loading, signup } = useSignup(formInputs);
-	const { authUser } = useAuthContext();
-
-	if (authUser) {
-		console.log(authUser._id);
-	}
 
 	const handleInputChange = (e) => {
 		const { name, value } = e.target;

--- a/client/src/utils/mutations.js
+++ b/client/src/utils/mutations.js
@@ -102,3 +102,9 @@ export const IS_TYPING_MUTATION = gql`
 		)
 	}
 `;
+
+export const UPDATE_LAST_SEEN = gql`
+	mutation Mutation($chatId: ID!) {
+		updateLastSeen(chatId: $chatId)
+	}
+`;

--- a/client/src/utils/mutations.js
+++ b/client/src/utils/mutations.js
@@ -104,7 +104,7 @@ export const IS_TYPING_MUTATION = gql`
 `;
 
 export const UPDATE_LAST_SEEN = gql`
-	mutation UpdateLastSeen($selectedChatId: ID!) {
-		updateLastSeen(selectedChatId: $selectedChatId)
+	mutation UpdateLastSeen($senderId: ID!, $receiverId: ID!) {
+		updateLastSeen(senderId: $senderId, receiverId: $receiverId)
 	}
 `;

--- a/client/src/utils/mutations.js
+++ b/client/src/utils/mutations.js
@@ -104,7 +104,7 @@ export const IS_TYPING_MUTATION = gql`
 `;
 
 export const UPDATE_LAST_SEEN = gql`
-	mutation Mutation($chatId: ID!) {
-		updateLastSeen(chatId: $chatId)
+	mutation UpdateLastSeen($selectedChatId: ID!) {
+		updateLastSeen(selectedChatId: $selectedChatId)
 	}
 `;

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -50,6 +50,14 @@ export const CHAT = gql`
 	query Chat($participantOne: ID!, $participantTwo: ID!) {
 		chat(participantOne: $participantOne, participantTwo: $participantTwo) {
 			_id
+			participantOne {
+				_id
+				username
+			}
+			participantTwo {
+				_id
+				username
+			}
 			participants {
 				_id
 				username

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -37,10 +37,29 @@ export const CHATS = gql`
 	query Chats {
 		chats {
 			_id
-			participants {
+			participantOne {
 				_id
 				username
 				avatar
+			}
+			participantTwo {
+				_id
+				username
+				avatar
+			}
+			lastSeenByOne
+			lastSeenByTwo
+			messages {
+				_id
+				senderId {
+					_id
+					username
+				}
+				receiverId {
+					_id
+					username
+				}
+				createdAt
 			}
 		}
 	}

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -116,3 +116,9 @@ export const VERIFY_TOKEN = gql`
 		}
 	}
 `;
+
+export const NOTIFICATIONS = gql`
+	query Notifications {
+		notifications
+	}
+`;

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -62,6 +62,8 @@ export const CHAT = gql`
 				_id
 				username
 			}
+			lastSeenByOne
+			lastSeenByTwo
 			messages {
 				_id
 				senderId {

--- a/client/src/utils/subscriptions.js
+++ b/client/src/utils/subscriptions.js
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client';
 
 export const NEW_MESSAGE = gql`
-	subscription NewMessage($authUserId: ID!, $selectedChatId: ID!) {
-		newMessage(authUserId: $authUserId, selectedChatId: $selectedChatId) {
+	subscription NewMessage($authUserId: ID!) {
+		newMessage(authUserId: $authUserId) {
 			senderId {
 				_id
 				username

--- a/client/src/utils/subscriptions.js
+++ b/client/src/utils/subscriptions.js
@@ -53,3 +53,13 @@ export const IS_TYPING_SUB = gql`
 		}
 	}
 `;
+
+export const LAST_SEEN_UPDATED_SUB = gql`
+	subscription LastSeenUpdatedSub {
+		lastSeenUpdatedSub {
+			senderId
+			receiverId
+			lastSeen
+		}
+	}
+`;

--- a/server/config/connection.js
+++ b/server/config/connection.js
@@ -3,6 +3,13 @@ dotenv.config();
 
 import mongoose from 'mongoose';
 
-mongoose.connect(process.env.MONGODB_URI);
+const connectionString =
+	process.env.NODE_ENV === 'development'
+		? 'mongodb://127.0.0.1:27017/vivoChat'
+		: process.env.MONGODB_URI;
+
+setTimeout(() => {
+	mongoose.connect(connectionString);
+}, 100);
 
 export default mongoose.connection;

--- a/server/config/connection.js
+++ b/server/config/connection.js
@@ -1,15 +1,9 @@
 import dotenv from 'dotenv';
 dotenv.config();
 
-import mongoose from 'mongoose';
-
 const connectionString =
 	process.env.NODE_ENV === 'development'
 		? 'mongodb://127.0.0.1:27017/vivoChat'
 		: process.env.MONGODB_URI;
 
-setTimeout(() => {
-	mongoose.connect(connectionString);
-}, 100);
-
-export default mongoose.connection;
+export default connectionString;

--- a/server/models/Chat.js
+++ b/server/models/Chat.js
@@ -18,6 +18,14 @@ const chatSchema = new mongoose.Schema(
 			ref: 'User',
 			required: true,
 		},
+		lastSeenByOne: {
+			type: Date,
+			default: 0,
+		},
+		lastSeenByTwo: {
+			type: Date,
+			default: 0,
+		},
 		messages: [
 			{
 				type: mongoose.Types.ObjectId,

--- a/server/models/Chat.js
+++ b/server/models/Chat.js
@@ -2,12 +2,22 @@ import mongoose from 'mongoose';
 
 const chatSchema = new mongoose.Schema(
 	{
-		participants: [
-			{
-				type: mongoose.Types.ObjectId,
-				ref: 'User',
-			},
-		],
+		// participants: [
+		// 	{
+		// 		type: mongoose.Types.ObjectId,
+		// 		ref: 'User',
+		// 	},
+		// ],
+		participantOne: {
+			type: mongoose.Types.ObjectId,
+			ref: 'User',
+			required: true,
+		},
+		participantTwo: {
+			type: mongoose.Types.ObjectId,
+			ref: 'User',
+			required: true,
+		},
 		messages: [
 			{
 				type: mongoose.Types.ObjectId,
@@ -18,8 +28,15 @@ const chatSchema = new mongoose.Schema(
 	},
 	{
 		timestamps: true,
+		toJSON: {
+			virtuals: true,
+		},
 	}
 );
+
+chatSchema.virtual('participants').get(function () {
+	return [this.participantOne, this.participantTwo];
+})
 
 const Chat = mongoose.model('Chat', chatSchema);
 

--- a/server/models/Chat.js
+++ b/server/models/Chat.js
@@ -2,12 +2,6 @@ import mongoose from 'mongoose';
 
 const chatSchema = new mongoose.Schema(
 	{
-		// participants: [
-		// 	{
-		// 		type: mongoose.Types.ObjectId,
-		// 		ref: 'User',
-		// 	},
-		// ],
 		participantOne: {
 			type: mongoose.Types.ObjectId,
 			ref: 'User',
@@ -42,9 +36,10 @@ const chatSchema = new mongoose.Schema(
 	}
 );
 
+// virtual to produce an array made up of the two participants
 chatSchema.virtual('participants').get(function () {
 	return [this.participantOne, this.participantTwo];
-})
+});
 
 const Chat = mongoose.model('Chat', chatSchema);
 

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -244,6 +244,9 @@ const resolvers = {
 				loggedIn: user._id.toString(),
 			});
 
+			// add new user to onlineUsers set
+			onlineUsers.add(user._id.toString());
+
 			return { token, user };
 		},
 		login: async (_parent, { username, password }, context) => {

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -64,10 +64,17 @@ const resolvers = {
 		// refactor to determine if there are notifications
 		chats: async (_parent, _args, context) => {
 			const chats = await Chat.find({
-				// participants: {
-				// 	$in: context.user._id,
-				// },
-			}).populate('participants');
+				$or: [
+					{
+						participantOne: context.user._id,
+					},
+					{
+						participantTwo: context.user._id,
+					},
+				],
+			})
+				.populate(['participantOne', 'participantTwo'])
+				.populate('messages');
 
 			if (!chats) {
 				throw new GraphQLError('Could not find any chats');
@@ -76,11 +83,6 @@ const resolvers = {
 			return chats;
 		},
 		chat: async (_parent, { participantOne, participantTwo }, context) => {
-			// const chat = await Chat.findOne({
-			// 	participants: {
-			// 		$all: [participantOne, participantTwo],
-			// 	},
-			// })
 			const chat = await Chat.findOne({
 				$or: [
 					{

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -75,7 +75,7 @@ const resolvers = {
 
 			return chats;
 		},
-		chat: async (_parent, { participantOne, participantTwo }, _context) => {
+		chat: async (_parent, { participantOne, participantTwo }, context) => {
 			// const chat = await Chat.findOne({
 			// 	participants: {
 			// 		$all: [participantOne, participantTwo],
@@ -99,6 +99,17 @@ const resolvers = {
 			if (!chat) {
 				throw new GraphQLError('No such chat exists');
 			}
+
+			// update lastSeenBy timestamp for appropriate user
+			if (chat.participantOne._id.toString() === context.user._id) {
+				chat.lastSeenByOne = new Date().toString();
+			} else if (
+				chat.participantTwo._id.toString() === context.user._id
+			) {
+				chat.lastSeenByTwo = new Date().toString();
+			}
+
+			await chat.save();
 
 			return chat;
 		},

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -308,6 +308,15 @@ const resolvers = {
 					senderId,
 				},
 			});
+			
+			// update lastSeenBy timestamp for appropriate user
+			if (chat.participantOne._id.toString() === context.user._id) {
+				chat.lastSeenByOne = new Date().toString();
+			} else if (
+				chat.participantTwo._id.toString() === context.user._id
+			) {
+				chat.lastSeenByTwo = new Date().toString();
+			}
 
 			// save updated/new documents to db in parallel
 			await Promise.all([chat.save(), newMessage.save()]);
@@ -370,6 +379,22 @@ const resolvers = {
 			pubsub.publish('IS_TYPING', {
 				isTypingSub: { senderId, receiverId, isTyping },
 			});
+		},
+		updateLastSeen: async (_parent, { chatId }, context) => {
+			const chat = await Chat.findById(chatId);
+
+			// update lastSeenBy timestamp for appropriate user
+			if (chat.participantOne._id.toString() === context.user._id) {
+				chat.lastSeenByOne = new Date().toString();
+			} else if (
+				chat.participantTwo._id.toString() === context.user._id
+			) {
+				chat.lastSeenByTwo = new Date().toString();
+			}
+
+			await chat.save();
+
+			return true;
 		},
 	},
 	Message: {

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -37,6 +37,12 @@ const typeDefs = `#graphql
 		isTyping: Boolean!
 	}
 
+	type LastSeenType {
+		senderId: ID!
+		receiverId: ID!
+		lastSeen: String!
+	}
+
 	type Query {
 		users: [User]!
 		user(userId: ID!): User
@@ -63,7 +69,7 @@ const typeDefs = `#graphql
 		
 		isTypingMutation(receiverId: ID!, senderId: ID!, isTyping: Boolean!): Boolean
 
-		updateLastSeen(selectedChatId: ID!): Boolean
+		updateLastSeen(senderId: ID!, receiverId: ID!): Boolean
 	}
 
 	type Subscription {
@@ -72,6 +78,7 @@ const typeDefs = `#graphql
 		loggedOut: ID
 		signedUp: User
 		isTypingSub: IsTypingIndicator
+		lastSeenUpdatedSub: LastSeenType
 	}
 `;
 

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -60,6 +60,8 @@ const typeDefs = `#graphql
 		createChat(participantOne: ID!, participantTwo: ID!): Chat
 		
 		isTypingMutation(receiverId: ID!, senderId: ID!, isTyping: Boolean!): Boolean
+
+		updateLastSeen(chatId: ID!): Boolean
 	}
 
 	type Subscription {

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -63,7 +63,7 @@ const typeDefs = `#graphql
 		
 		isTypingMutation(receiverId: ID!, senderId: ID!, isTyping: Boolean!): Boolean
 
-		updateLastSeen(chatId: ID!): Boolean
+		updateLastSeen(selectedChatId: ID!): Boolean
 	}
 
 	type Subscription {

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -19,6 +19,8 @@ const typeDefs = `#graphql
 		_id: ID!
 		participantOne: User!
 		participantTwo: User!
+		lastSeenByOne: String!
+		lastSeenByTwo: String!
 		participants: [User!]!
 		messages: [Message!]!
 		# timestamps

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -17,6 +17,8 @@ const typeDefs = `#graphql
 
 	type Chat {
 		_id: ID!
+		participantOne: User!
+		participantTwo: User!
 		participants: [User!]!
 		messages: [Message!]!
 		# timestamps

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -49,6 +49,8 @@ const typeDefs = `#graphql
 		getOnlineUsers: [ID]
 
 		verifyToken(token: ID!): Auth
+
+		notifications: [ID]
 	}
 
 	type Mutation {

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -65,7 +65,7 @@ const typeDefs = `#graphql
 	}
 
 	type Subscription {
-		newMessage(authUserId: ID!, selectedChatId: ID!): Message
+		newMessage(authUserId: ID!): Message
 		loggedIn: ID
 		loggedOut: ID
 		signedUp: User

--- a/server/server.js
+++ b/server/server.js
@@ -8,7 +8,8 @@ import path from 'path';
 import { authMiddleware } from './utils/auth.js';
 
 import { typeDefs, resolvers } from './schemas/index.js';
-import db from './config/connection.js';
+import mongoose from 'mongoose';
+import connectionString from './config/connection.js';
 import cookieParser from 'cookie-parser';
 
 // graphql subscription/websocket imports
@@ -107,6 +108,9 @@ const startApolloServer = async () => {
 			res.sendFile(path.join(__dirname, '/client/dist/index.html'));
 		});
 	}
+
+	mongoose.connect(connectionString);
+	const db = mongoose.connection;
 
 	// once connection to db is open begin listening
 	db.once('open', () => {


### PR DESCRIPTION
- Converted Chat model's participant array into two fields; participantOne and participantTwo
- Added lastSeenByOne and lastSeenByTwo fields to Chat
- Updated existing resolvers to work with new data structure
- Created updateLastSeen mutation to update the appropriate field (one or two) of a Chat document
- Created lastSeenUpdatedSub subscription to publish to when a Chat's lastSeenByX field is updated
- Used new fields in combination with existing state-based notifications to persist notification over refresh/logout and login
- Implemented lastSeenUpdatedSub in order to dynamically render sent/read receipts for all messages sent by user
- Rearranged the configuration/connection to mongodb to ensure db.once() is available at the right time